### PR TITLE
Fix formatting and layout issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Features
 4. Simulate dialogue right in the app
 
 Drag a character card from the sidebar onto the canvas to start a new tree.
-Drag a character card from the sidebar onto an existingg card on the canvas to create a new card and automatically link them.
+Drag a character card from the sidebar onto an existing card on the canvas to create a new card and automatically link them.
 Right click on a card to access options such as reparenting, creating new links, deleting links, or deleting the card.

--- a/script.js
+++ b/script.js
@@ -1356,7 +1356,7 @@ document.getElementById("simulate").addEventListener("click", () => {
       errorMessage.className = "error-message";
       errorMessage.style.color = "#e74c3c"; // Optional: Style the error message in red
       errorMessage.style.marginTop = "10px";
-      errorMessage.innerHTML = `<em>Current node has multiple children that are not all Choice nodes. Please ensure all children are Choice nodes or limit to a single Dialogue/Action child.</em>`;
+      errorMessage.innerHTML = "<em>Current node has multiple children that are not all Choice nodes. Please ensure all children are Choice nodes or limit to a single Dialogue/Action child.</em>";
       simulationChoices.appendChild(errorMessage);
       return;
     }

--- a/styles.css
+++ b/styles.css
@@ -61,7 +61,6 @@ body {
 
 #sidebar-logo {
     width: 40px; /* Adjust size as needed */
-    height: 40px;
     height: auto;
     display: block;
     margin: 0 auto 10px auto; /* Center and add space below the logo */


### PR DESCRIPTION
## Summary
- Prevent unintended line breaks in multi-child error message
- Remove conflicting height declarations for the sidebar logo
- Correct a spelling mistake in the README

## Testing
- `node --check script.js`
- `npx -y csslint styles.css` *(reports issues with CSS variables)*

------
https://chatgpt.com/codex/tasks/task_e_6893963994f8832aa199be9df419e633