### PR TITLE
Add global simulate mode button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Features
 1. No login, no back end. Everything happens in your browser.
 2. Export trees for use in other programs.
 3. Import trees to continue your work.
-4. Simulate dialogue right in the app
+4. Simulate dialogue right in the app using the Simulate Mode button
 
 Drag a character card from the sidebar onto the canvas to start a new tree.
 Drag a character card from the sidebar onto an existing card on the canvas to create a new card and automatically link them.

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       <!-- Export and Import Buttons -->
       <button id="exportButton">Export Data</button>
       <button id="importButton">Import Data</button>
+      <button id="simulateAllButton">Simulate Mode</button>
       <!-- Hidden File Input for Import -->
       <input type="file" id="importFileInput" accept=".json" style="display: none;" />
     </div>

--- a/script.js
+++ b/script.js
@@ -22,11 +22,23 @@
   const exportButton = document.getElementById("exportButton");
   const importButton = document.getElementById("importButton");
   const importFileInput = document.getElementById("importFileInput");
+  const simulateAllButton = document.getElementById("simulateAllButton");
 
   addCharacterButton.addEventListener("click", addCharacter);
   exportButton.addEventListener("click", exportData);
   importButton.addEventListener("click", () => importFileInput.click());
   importFileInput.addEventListener("change", importData);
+  simulateAllButton.addEventListener("click", () => {
+    const rootNodes = nodes.filter((n) => n.parentIds.length === 0);
+    if (rootNodes.length === 0) {
+      alert("No nodes available for simulation.");
+      return;
+    }
+    if (rootNodes.length > 1) {
+      alert("Multiple root nodes found. Starting simulation from the first root.");
+    }
+    startSimulation(rootNodes[0].id);
+  });
 
   // Prevent the default context menu from appearing on the storyMap
   storyMap.addEventListener("contextmenu", (e) => {

--- a/styles.css
+++ b/styles.css
@@ -196,7 +196,8 @@ body {
 
 #addCharacterButton,
 #exportButton,
-#importButton {
+#importButton,
+#simulateAllButton {
     width: calc(100% - 40px);
     margin: 0 20px 20px 20px;
     padding: 15px;
@@ -213,7 +214,8 @@ body {
 
 #addCharacterButton:hover,
 #exportButton:hover,
-#importButton:hover {
+#importButton:hover,
+#simulateAllButton:hover {
     background-color: #666666;
 }
 


### PR DESCRIPTION
## Summary
- add sidebar Simulate Mode button to start dialogue flow
- style new button with existing sidebar buttons
- document global simulation in README

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6893a121dbc4832ab2db68c79787af55